### PR TITLE
Improve feature set storage method, fix board definitions and other bugs

### DIFF
--- a/ArduinoBoardManager.cpp
+++ b/ArduinoBoardManager.cpp
@@ -37,23 +37,7 @@
 
 ArduinoBoardManager::ArduinoBoardManager() {
   // clear the features
-  memset(FEATURES, false, NUM_FEATURES);
-
-
-
-  static const unsigned long BOARD_UNKNOWN = 0x0;
-  static const unsigned long BOARD_UNO = 0x01;
-  static const unsigned long BOARD_ZERO = 0x02;
-  static const unsigned long BOARD_DUE = 0x03;
-  static const unsigned long BOARD_MICRO= 0x04;
-  static const unsigned long BOARD_YUN_400 = 0x05;
-  static const unsigned long BOARD_LEONARDO = 0x06;
-  static const unsigned long BOARD_MEGA = 0x07;
-  static const unsigned long BOARD_NANO = 0x08;
-  static const unsigned long BOARD_NANO_3 = 0x09;
-  static const unsigned long BOARD_LILYPAD = 0x08;
-  static const unsigned long BOARD_TRINKET = 0x09;
-
+    m_features = 0;
 
   switch (ArduinoBoardManager::BOARD) {
     case ArduinoBoardManager::BOARD_UNO:
@@ -63,12 +47,12 @@ ArduinoBoardManager::ArduinoBoardManager() {
     case ArduinoBoardManager::BOARD_ZERO:
       strcpy(BOARD_NAME, "Zero");
       strcpy(CPU_NAME, "ATSAMD21G18A");
-      FEATURES[ArduinoBoardManager::FEATURE_ANALOG_OUT] = true;
+      m_features = FEATURE_ANALOG_OUT;
     break;
     case ArduinoBoardManager::BOARD_DUE:
       strcpy(BOARD_NAME, "Due");
       strcpy(CPU_NAME, "ATSAM3X8E");
-      FEATURES[ArduinoBoardManager::FEATURE_ANALOG_OUT] = true;
+      m_features = FEATURE_ANALOG_OUT;
     break;
     case ArduinoBoardManager::BOARD_MICRO:
       strcpy(BOARD_NAME, "Micro");
@@ -85,7 +69,7 @@ ArduinoBoardManager::ArduinoBoardManager() {
     case ArduinoBoardManager::BOARD_MEGA:
       strcpy(BOARD_NAME, "Mega");
       strcpy(CPU_NAME, "ATmega1280");
-      FEATURES[ArduinoBoardManager::FEATURE_MULTIPLE_SERIAL] = true;
+      m_features = FEATURE_MULTIPLE_SERIAL;
     break;
     case ArduinoBoardManager::BOARD_NANO:
       strcpy(BOARD_NAME, "Nano");
@@ -110,23 +94,16 @@ ArduinoBoardManager::ArduinoBoardManager() {
     case ArduinoBoardManager::BOARD_101:
       strcpy(BOARD_NAME, "101");
       strcpy(CPU_NAME, "ARCv2EM");
-      FEATURES[ArduinoBoardManager::FEATURE_BLUETOOTH_4] = true;
-      FEATURES[ArduinoBoardManager::FEATURE_ACCELEROMETER] = true;
-      FEATURES[ArduinoBoardManager::FEATURE_GYROSCOPE] = true;
+      m_features = FEATURE_BLUETOOTH_4 | FEATURE_ACCELEROMETER | FEATURE_GYROSCOPE;
     break;
     default:
       strcpy(BOARD_NAME, "Unknown");
       strcpy(CPU_NAME, "Unknown");
-
+    break;
   }
-
 }
 
-
 bool ArduinoBoardManager::featureExists(uint8_t feature) {
-  if ((feature < ArduinoBoardManager::NUM_FEATURES) &&
-     (ArduinoBoardManager::FEATURES[feature]))
-      return true;
-  return false;
+    return m_features & feature;
 }
 

--- a/ArduinoBoardManager.cpp
+++ b/ArduinoBoardManager.cpp
@@ -66,11 +66,16 @@ ArduinoBoardManager::ArduinoBoardManager() {
       strcpy(BOARD_NAME, "Leonardo");
       strcpy(CPU_NAME, "ATmega16U4");
     break;
-    case ArduinoBoardManager::BOARD_MEGA:
+    case ArduinoBoardManager::BOARD_MEGA_1280:
       strcpy(BOARD_NAME, "Mega");
       strcpy(CPU_NAME, "ATmega1280");
       m_features = FEATURE_MULTIPLE_SERIAL;
     break;
+    case ArduinoBoardManager::BOARD_MEGA_2560:
+      strcpy(BOARD_NAME, "Mega");
+      strcpy(CPU_NAME, "ATmega2560");
+      m_features = FEATURE_MULTIPLE_SERIAL;
+      break;
     case ArduinoBoardManager::BOARD_NANO:
       strcpy(BOARD_NAME, "Nano");
       strcpy(CPU_NAME, "ATmega168");

--- a/ArduinoBoardManager.h
+++ b/ArduinoBoardManager.h
@@ -102,105 +102,109 @@ class ArduinoBoardManager {
   static const uint16_t CPU = __AVR_ATmega328P__;     /**< 16Mhz */
   static const unsigned long SRAM_SIZE = 2000;       /**< 2kb of sram */
   static const unsigned long EEPROM_SIZE = 1000;     /**< 1kb eeprom */
-  static const unsigned long FLASH_SIZE = 32000;     /**< 32k flash storage */
+  static const unsigned long BOARD_FLASH_SIZE = 32000;     /**< 32k flash storage */
 #elif defined(__AVR_ATSAMD21G18A__) // zero
   static const uint8_t BOARD = BOARD_ZERO
   static const uint8_t NUM_BITS = 8;
   static const uint16_t CPU = __AVR_ATSAMD21G18A__;
   static const unsigned long SRAM_SIZE = 32000;
   static const unsigned long EEPROM_SIZE = 16000;
-  static const unsigned long FLASH_SIZE = 256000;
+  static const unsigned long BOARD_FLASH_SIZE = 256000;
 #elif defined(__AVR_ATSAM3X8E__) // Due
   static const uint8_t BOARD = BOARD_DUE;
   static const uint8_t NUM_BITS = 8;
   static const uint16_t CPU = __AVR_ATSAMD21G18A__;
   static const unsigned long SRAM_SIZE = 96000;
   static const unsigned long EEPROM_SIZE = 0;
-  static const unsigned long FLASH_SIZE = 512000;
+  static const unsigned long BOARD_FLASH_SIZE = 512000;
 #elif defined(__AVR_ATmega32U4__) // Yun 16Mhz, Micro, Leonardo, Esplora
   static const uint8_t BOARD = BOARD_MICRO;
   static const uint8_t NUM_BITS = 8;
   static const uint16_t CPU = __AVR_Atmega32U4__;
   static const unsigned long SRAM_SIZE = 2500;
   static const unsigned long EEPROM_SIZE = 1000;
-  static const unsigned long FLASH_SIZE = 32000;
+  static const unsigned long BOARD_FLASH_SIZE = 32000;
 #elif defined(_AVR_AR9331__) // Yun 400Mhz
   static const uint8_t BOARD = BOARD_YUN_400;
   static const uint8_t NUM_BITS = 8;
   static const uint16_t CPU = _AVR_AR9331__;
   static const unsigned long SRAM_SIZE = 64000000;
   static const unsigned long EEPROM_SIZE = 0;
-  static const unsigned long FLASH_SIZE = 16000000;
+  static const unsigned long BOARD_FLASH_SIZE = 16000000;
 #elif defined(__AVR_ATmega16U4__) // leonardo
   static const uint8_t BOARD = BOARD_LEONARDO;
   static const uint8_t NUM_BITS = 8;
   static const uint16_t CPU = __AVR_ATmega16U4__;
   static const unsigned long SRAM_SIZE = 2560;
   static const unsigned long EEPROM_SIZE = 1000;
-  static const unsigned long FLASH_SIZE = 32000;
+  static const unsigned long BOARD_FLASH_SIZE = 32000;
 #elif defined(__AVR_ATmega1280__) // mega, Mega ADK (ATmega 1280)
   static const uint8_t BOARD = BOARD_MEGA_1280;
   static const uint8_t NUM_BITS = 8;
   static const uint16_t CPU = __AVR_ATmega1280__;
   static const unsigned long SRAM_SIZE = 8000;
   static const unsigned long EEPROM_SIZE = 4000;
-  static const unsigned long FLASH_SIZE = 256000;
+  static const unsigned long BOARD_FLASH_SIZE = 256000;
 #elif defined(__AVR_ATmega2560__) // mega, Mega ADK (ATmega 2560)
     static const uint8_t BOARD = BOARD_MEGA_2560;
     static const uint8_t NUM_BITS = 8;
     static const uint16_t CPU = __AVR_ATmega2560__;
     static const unsigned long SRAM_SIZE = 8000;
     static const unsigned long EEPROM_SIZE = 4000;
-    static const unsigned long FLASH_SIZE = 256000;
+    static const unsigned long BOARD_FLASH_SIZE = 256000;
 #elif defined(_AVR_ATmega328__) // Nano >= v3.0 or Arduino Pro, pro328, ethernet
   static const uint8_t BOARD = BOARD_NANO;
   static const uint8_t NUM_BITS = 8;
   static const uint16_t CPU = _AVR_ATmega328__;
   static const unsigned long SRAM_SIZE = 2000;
   static const unsigned long EEPROM_SIZE = 1000;
-  static const unsigned long FLASH_SIZE = 32000;
+  static const unsigned long BOARD_FLASH_SIZE = 32000;
 #elif defined(_AVR_ATmega168__) // Nano < v3.0 or uno, pro
   static const uint8_t BOARD = BOARD_NANO_3;
   static const uint8_t NUM_BITS = 8;
   static const uint16_t CPU = _AVR_ATmega168;
   static const unsigned long SRAM_SIZE = 1000;
   static const unsigned long EEPROM_SIZE = 500;
-  static const unsigned long FLASH_SIZE = 16000;
+  static const unsigned long BOARD_FLASH_SIZE = 16000;
 #elif defined(_AVR_ATmega168V__) // LilyPad
   static const uint8_t BOARD = BOARD_LILYPAD;
   static const uint8_t CPU = _AVR_ATmega168V__;
   static const unsigned int NUM_BITS = 8;
   static const unsigned long SRAM_SIZE = 1000;
   static const unsigned long EEPROM_SIZE = 500;
-  static const unsigned long FLASH_SIZE = 14000
+  static const unsigned long BOARD_FLASH_SIZE = 14000
 #elif defined(_AVR_ATmega328V__) // LilyPad 2
   static const uint8_t BOARD = BOARD_LILYPAD_2;
   static const uint8_t CPU = _AVR_ATmega328V__;
   static const unsigned int NUM_BITS = 8;
   static const unsigned long SRAM_SIZE = 1000;
   static const unsigned long EEPROM_SIZE = 500;
-  static const unsigned long FLASH_SIZE = 14000
+  static const unsigned long BOARD_FLASH_SIZE = 14000
 #elif defined(_AVR_ATTiny85__) // trinket
   static const uint8_t BOARD = BOARD_TRINKET;
   static const uint8_t NUM_BITS = 8;
   static const uint16_t CPU = _AVR_ATTiny85__;
   static const unsigned long SRAM_SIZE = 500;
   static const unsigned long EEPROM_SIZE = 500;
-  static const unsigned long FLASH_SIZE = 2500;
+  static const unsigned long BOARD_FLASH_SIZE = 2500;
 #elif  defined(__AVR_ARCv2EM__) || (__CURIE_FACTORY_DATA_H_) // Intel Curie/101
   static const uint8_t BOARD = BOARD_101;
   static const uint8_t NUM_BITS = 32;
   static const uint16_t CPU = __AVR_ARCv2EM__;
   static const unsigned long SRAM_SIZE = 24000; // might be 80k?
   static const unsigned long EEPROM_SIZE = 0;
-  static const unsigned long FLASH_SIZE = 384000;
+  static const unsigned long BOARD_FLASH_SIZE = 384000;
 #else
   static const uint8_t BOARD = BOARD_UNKNOWN;
   static const uint8_t NUM_BITS = 0;
   static const uint16_t CPU = 0;
   static const unsigned long SRAM_SIZE = 0;
   static const unsigned long EEPROM_SIZE = 0;
-  static const unsigned long FLASH_SIZE = 0;
+#if !defined(FLASH_SIZE)
+  static const unsigned long BOARD_FLASH_SIZE = 0;
+#else
+  static const unsigned long BOARD_FLASH_SIZE = FLASH_SIZE;
+#endif
 #endif
 
   /**

--- a/ArduinoBoardManager.h
+++ b/ArduinoBoardManager.h
@@ -1,3 +1,6 @@
+#ifndef _Arduino_Board_Manager_h_
+#define _Arduino_Board_Manager_h_
+
 /*-------------------------------------------------------------------------
   Arduino library to determine the Arduino models and features,
   as well as the SDK version.
@@ -214,3 +217,4 @@ class ArduinoBoardManager {
   
 };
 
+#endif

--- a/ArduinoBoardManager.h
+++ b/ArduinoBoardManager.h
@@ -15,7 +15,8 @@
   @author Tony Gaitatzis backupbrain@gmail.com
   @date 2015-12-10
 
-  -------------------------------------------------------------------------
+ -------------------------------------------------------------------------
+
   This file is part of the Arduino Board Manager library
 
   NeoPixel is free software: you can redistribute it and/or modify
@@ -49,8 +50,8 @@ class ArduinoBoardManager {
   /**
    * Board Name 
    */
-  static const uint8_t MAX_BOARD_NAME_LENGTH = 16; 
-  static const uint8_t MAX_CPU_NAME_LENGTH = 16;        
+  static const uint8_t MAX_BOARD_NAME_LENGTH = 16;
+  static const uint8_t MAX_CPU_NAME_LENGTH = 16;
   char BOARD_NAME[MAX_BOARD_NAME_LENGTH];                       /**< When instantiated, this is the board name, eg "UNO" */    
   char CPU_NAME[MAX_CPU_NAME_LENGTH];                       /**< When instantiated, this is the cpu name, eg "__AVR_ATmega328P__" */
 
@@ -61,7 +62,7 @@ class ArduinoBoardManager {
   static const uint8_t BOARD_UNO = 0x01;
   static const uint8_t BOARD_ZERO = 0x02;
   static const uint8_t BOARD_DUE = 0x03;
-  static const uint8_t BOARD_MICRO= 0x04;
+  static const uint8_t BOARD_MICRO = 0x04;
   static const uint8_t BOARD_YUN_400 = 0x05;
   static const uint8_t BOARD_LEONARDO = 0x06;
   static const uint8_t BOARD_MEGA = 0x07;
@@ -75,19 +76,18 @@ class ArduinoBoardManager {
   /**
    * Known Arduino Features 
    */
-  static const uint8_t NUM_FEATURES = 1;
-  static const uint8_t FEATURE_MULTIPLE_SERIAL = 0x00;
-  static const uint8_t FEATURE_BLUETOOTH_4 = 0x01;
-  static const uint8_t FEATURE_ACCELEROMETER = 0x02;
-  static const uint8_t FEATURE_GYROSCOPE = 0x03;
-  static const uint8_t FEATURE_ANALOG_OUT = 0x04;
+  static const uint8_t FEATURE_MULTIPLE_SERIAL = 0x01;
+  static const uint8_t FEATURE_BLUETOOTH_4 = 0x02;
+  static const uint8_t FEATURE_ACCELEROMETER = 0x04;
+  static const uint8_t FEATURE_GYROSCOPE = 0x08;
+  static const uint8_t FEATURE_ANALOG_OUT = 0x10;
 
   /**
    * CPU speed
    */
   static const unsigned long MAX_MHZ = F_CPU;
-  
-  boolean FEATURES[NUM_FEATURES];
+
+    uint8_t m_features;
   
   /**
    * CPU Specifications
@@ -134,13 +134,20 @@ class ArduinoBoardManager {
   static const unsigned long SRAM_SIZE = 2560;
   static const unsigned long EEPROM_SIZE = 1000;
   static const unsigned long FLASH_SIZE = 32000;
-#elif defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) // mega, Mega ADK
+#elif defined(__AVR_ATmega1280__) // mega, Mega ADK (ATmega 1280)
   static const uint8_t BOARD = 0x07;
   static const uint8_t NUM_BITS = 8;
   static const uint16_t CPU = __AVR_ATmega1280__;
   static const unsigned long SRAM_SIZE = 8000;
   static const unsigned long EEPROM_SIZE = 4000;
   static const unsigned long FLASH_SIZE = 256000;
+#elif defined(__AVR_ATmega2560__) // mega, Mega ADK (ATmega 2560)
+    static const uint8_t BOARD = 0x07;
+    static const uint8_t NUM_BITS = 8;
+    static const uint16_t CPU = __AVR_ATmega2560__;
+    static const unsigned long SRAM_SIZE = 8000;
+    static const unsigned long EEPROM_SIZE = 4000;
+    static const unsigned long FLASH_SIZE = 256000;
 #elif defined(_AVR_ATmega328__) // Nano >= v3.0 or Arduino Pro, pro328, ethernet
   static const uint8_t BOARD = 0x08;
   static const uint8_t NUM_BITS = 8;

--- a/ArduinoBoardManager.h
+++ b/ArduinoBoardManager.h
@@ -113,7 +113,7 @@ class ArduinoBoardManager {
   static const unsigned long SRAM_SIZE = 96000;
   static const unsigned long EEPROM_SIZE = 0;
   static const unsigned long FLASH_SIZE = 512000;
-#elif defined(__AVR_Atmega32U4__) // Yun 16Mhz, Micro, Leonardo, Esplora
+#elif defined(__AVR_ATmega32U4__) // Yun 16Mhz, Micro, Leonardo, Esplora
   static const uint8_t BOARD = 0x04;
   static const uint8_t NUM_BITS = 8;
   static const uint16_t CPU = __AVR_Atmega32U4__;

--- a/ArduinoBoardManager.h
+++ b/ArduinoBoardManager.h
@@ -93,105 +93,105 @@ class ArduinoBoardManager {
    * CPU Specifications
    */
 #if defined(__AVR_ATmega328P__) // uno, fio
-  static const uint8_t BOARD = 0x01;           /**< UNO board */
+  static const uint8_t BOARD = BOARD_UNO;           /**< UNO board */
   static const uint8_t NUM_BITS = 8;            /**< 8-bit processor */
   static const uint16_t CPU = __AVR_ATmega328P__;     /**< 16Mhz */
   static const unsigned long SRAM_SIZE = 2000;       /**< 2kb of sram */
   static const unsigned long EEPROM_SIZE = 1000;     /**< 1kb eeprom */
   static const unsigned long FLASH_SIZE = 32000;     /**< 32k flash storage */
 #elif defined(__AVR_ATSAMD21G18A__) // zero
-  static const uint8_t BOARD = 0x02
+  static const uint8_t BOARD = BOARD_ZERO
   static const uint8_t NUM_BITS = 8;
   static const uint16_t CPU = __AVR_ATSAMD21G18A__;
   static const unsigned long SRAM_SIZE = 32000;
   static const unsigned long EEPROM_SIZE = 16000;
   static const unsigned long FLASH_SIZE = 256000;
 #elif defined(__AVR_ATSAM3X8E__) // Due
-  static const uint8_t BOARD = 0x03;
+  static const uint8_t BOARD = BOARD_DUE;
   static const uint8_t NUM_BITS = 8;
   static const uint16_t CPU = __AVR_ATSAMD21G18A__;
   static const unsigned long SRAM_SIZE = 96000;
   static const unsigned long EEPROM_SIZE = 0;
   static const unsigned long FLASH_SIZE = 512000;
 #elif defined(__AVR_Atmega32U4__) // Yun 16Mhz, Micro, Leonardo, Esplora
-  static const uint8_t BOARD = 0x04;
+  static const uint8_t BOARD = BOARD_MICRO;
   static const uint8_t NUM_BITS = 8;
   static const uint16_t CPU = __AVR_Atmega32U4__;
   static const unsigned long SRAM_SIZE = 2500;
   static const unsigned long EEPROM_SIZE = 1000;
   static const unsigned long FLASH_SIZE = 32000;
 #elif defined(_AVR_AR9331__) // Yun 400Mhz
-  static const uint8_t BOARD = 0x05;
+  static const uint8_t BOARD = BOARD_YUN_400;
   static const uint8_t NUM_BITS = 8;
   static const uint16_t CPU = _AVR_AR9331__;
   static const unsigned long SRAM_SIZE = 64000000;
   static const unsigned long EEPROM_SIZE = 0;
   static const unsigned long FLASH_SIZE = 16000000;
 #elif defined(__AVR_ATmega16U4__) // leonardo
-  static const uint8_t BOARD = 0x06;
+  static const uint8_t BOARD = BOARD_LEONARDO;
   static const uint8_t NUM_BITS = 8;
   static const uint16_t CPU = __AVR_ATmega16U4__;
   static const unsigned long SRAM_SIZE = 2560;
   static const unsigned long EEPROM_SIZE = 1000;
   static const unsigned long FLASH_SIZE = 32000;
 #elif defined(__AVR_ATmega1280__) // mega, Mega ADK (ATmega 1280)
-  static const uint8_t BOARD = 0x07;
+  static const uint8_t BOARD = BOARD_MEGA;
   static const uint8_t NUM_BITS = 8;
   static const uint16_t CPU = __AVR_ATmega1280__;
   static const unsigned long SRAM_SIZE = 8000;
   static const unsigned long EEPROM_SIZE = 4000;
   static const unsigned long FLASH_SIZE = 256000;
 #elif defined(__AVR_ATmega2560__) // mega, Mega ADK (ATmega 2560)
-    static const uint8_t BOARD = 0x07;
+    static const uint8_t BOARD = BOARD_MEGA;
     static const uint8_t NUM_BITS = 8;
     static const uint16_t CPU = __AVR_ATmega2560__;
     static const unsigned long SRAM_SIZE = 8000;
     static const unsigned long EEPROM_SIZE = 4000;
     static const unsigned long FLASH_SIZE = 256000;
 #elif defined(_AVR_ATmega328__) // Nano >= v3.0 or Arduino Pro, pro328, ethernet
-  static const uint8_t BOARD = 0x08;
+  static const uint8_t BOARD = BOARD_NANO;
   static const uint8_t NUM_BITS = 8;
   static const uint16_t CPU = _AVR_ATmega328__;
   static const unsigned long SRAM_SIZE = 2000;
   static const unsigned long EEPROM_SIZE = 1000;
   static const unsigned long FLASH_SIZE = 32000;
 #elif defined(_AVR_ATmega168__) // Nano < v3.0 or uno, pro
-  static const uint8_t BOARD = 0x09;
+  static const uint8_t BOARD = BOARD_NANO_3;
   static const uint8_t NUM_BITS = 8;
   static const uint16_t CPU = _AVR_ATmega168;
   static const unsigned long SRAM_SIZE = 1000;
   static const unsigned long EEPROM_SIZE = 500;
   static const unsigned long FLASH_SIZE = 16000;
 #elif defined(_AVR_ATmega168V__) // LilyPad
-  static const uint8_t BOARD = 0x0a;
+  static const uint8_t BOARD = BOARD_LILYPAD;
   static const uint8_t CPU = _AVR_ATmega168V__;
   static const unsigned int NUM_BITS = 8;
   static const unsigned long SRAM_SIZE = 1000;
   static const unsigned long EEPROM_SIZE = 500;
   static const unsigned long FLASH_SIZE = 14000
 #elif defined(_AVR_ATmega328V__) // LilyPad 2
-  static const uint8_t BOARD = 0x0b;
+  static const uint8_t BOARD = BOARD_LILYPAD_2;
   static const uint8_t CPU = _AVR_ATmega328V__;
   static const unsigned int NUM_BITS = 8;
   static const unsigned long SRAM_SIZE = 1000;
   static const unsigned long EEPROM_SIZE = 500;
   static const unsigned long FLASH_SIZE = 14000
 #elif defined(_AVR_ATTiny85__) // trinket
-  static const uint8_t BOARD = 0x0c;
+  static const uint8_t BOARD = BOARD_TRINKET;
   static const uint8_t NUM_BITS = 8;
   static const uint16_t CPU = _AVR_ATTiny85__;
   static const unsigned long SRAM_SIZE = 500;
   static const unsigned long EEPROM_SIZE = 500;
   static const unsigned long FLASH_SIZE = 2500;
 #elif  defined(__AVR_ARCv2EM__) || (__CURIE_FACTORY_DATA_H_) // Intel Curie/101
-  static const uint8_t BOARD = 0x0d;
+  static const uint8_t BOARD = BOARD_101;
   static const uint8_t NUM_BITS = 32;
   static const uint16_t CPU = __AVR_ARCv2EM__;
   static const unsigned long SRAM_SIZE = 24000; // might be 80k?
   static const unsigned long EEPROM_SIZE = 0;
   static const unsigned long FLASH_SIZE = 384000;
 #else
-  static const uint8_t BOARD = 0x00;
+  static const uint8_t BOARD = BOARD_UNKNOWN;
   static const uint8_t NUM_BITS = 0;
   static const uint16_t CPU = 0;
   static const unsigned long SRAM_SIZE = 0;

--- a/ArduinoBoardManager.h
+++ b/ArduinoBoardManager.h
@@ -7,11 +7,11 @@
 
   Most features can be accessed via static variables.
   You must instantiate if you want to know if the name of the board
-  or if specific features such exist, for example multiple serial 
+  or if specific features such exist, for example multiple serial
   connections on the Arduino Mega.
 
   This list may be neither comprehensive nor up to date
-  
+
   A full list of boards and processor names are available on Wikipedia:
   https://en.wikipedia.org/wiki/List_of_Arduino_boards_and_compatible_systems
 
@@ -36,7 +36,7 @@
   License along with NeoPixel.  If not, see
   <http://www.gnu.org/licenses/>.
   -------------------------------------------------------------------------*/
-  
+
 #if ARDUINO >= 100
   #include <Arduino.h>
 #else
@@ -51,7 +51,7 @@ class ArduinoBoardManager {
   static const uint16_t SDK_VERSION = ARDUINO;        /**< Arduino SDK Version */
 
   /**
-   * Board Name 
+   * Board Name
    */
   static const uint8_t MAX_BOARD_NAME_LENGTH = 16;
   static const uint8_t MAX_CPU_NAME_LENGTH = 16;
@@ -68,13 +68,14 @@ class ArduinoBoardManager {
   static const uint8_t BOARD_MICRO = 0x04;
   static const uint8_t BOARD_YUN_400 = 0x05;
   static const uint8_t BOARD_LEONARDO = 0x06;
-  static const uint8_t BOARD_MEGA = 0x07;
-  static const uint8_t BOARD_NANO = 0x08;
-  static const uint8_t BOARD_NANO_3 = 0x09;
-  static const uint8_t BOARD_LILYPAD = 0x0a;
-  static const uint8_t BOARD_LILYPAD_2 = 0x0b;
-  static const uint8_t BOARD_TRINKET = 0x0c;
-  static const uint8_t BOARD_101 = 0x0d;
+  static const uint8_t BOARD_MEGA_1280 = 0x07;
+  static const uint8_t BOARD_MEGA_2560 = 0x08;
+  static const uint8_t BOARD_NANO = 0x09;
+  static const uint8_t BOARD_NANO_3 = 0x0a;
+  static const uint8_t BOARD_LILYPAD = 0x0b;
+  static const uint8_t BOARD_LILYPAD_2 = 0x0c;
+  static const uint8_t BOARD_TRINKET = 0x0d;
+  static const uint8_t BOARD_101 = 0x0e;
 
   /**
    * Known Arduino Features 
@@ -138,14 +139,14 @@ class ArduinoBoardManager {
   static const unsigned long EEPROM_SIZE = 1000;
   static const unsigned long FLASH_SIZE = 32000;
 #elif defined(__AVR_ATmega1280__) // mega, Mega ADK (ATmega 1280)
-  static const uint8_t BOARD = BOARD_MEGA;
+  static const uint8_t BOARD = BOARD_MEGA_1280;
   static const uint8_t NUM_BITS = 8;
   static const uint16_t CPU = __AVR_ATmega1280__;
   static const unsigned long SRAM_SIZE = 8000;
   static const unsigned long EEPROM_SIZE = 4000;
   static const unsigned long FLASH_SIZE = 256000;
 #elif defined(__AVR_ATmega2560__) // mega, Mega ADK (ATmega 2560)
-    static const uint8_t BOARD = BOARD_MEGA;
+    static const uint8_t BOARD = BOARD_MEGA_2560;
     static const uint8_t NUM_BITS = 8;
     static const uint16_t CPU = __AVR_ATmega2560__;
     static const unsigned long SRAM_SIZE = 8000;

--- a/examples/featuresniffer/featuresniffer.ino
+++ b/examples/featuresniffer/featuresniffer.ino
@@ -27,7 +27,7 @@ void setup() {
   Serial.print("-bit, "); Serial.print(ArduinoBoardManager::MAX_MHZ/M);
   Serial.print("Mhz processor with "); Serial.print(ArduinoBoardManager::SRAM_SIZE/k);
   Serial.print("k of SRAM, "); Serial.print(ArduinoBoardManager::EEPROM_SIZE/k);
-  Serial.print("k of EEPROM and "); Serial.print(ArduinoBoardManager::FLASH_SIZE/k);
+  Serial.print("k of EEPROM and "); Serial.print(ArduinoBoardManager::BOARD_FLASH_SIZE/k);
   Serial.println("k of flash.");
   Serial.println();
   

--- a/examples/featuresniffer/featuresniffer.ino
+++ b/examples/featuresniffer/featuresniffer.ino
@@ -1,6 +1,5 @@
 #include <ArduinoBoardManager.h>
 
-
 ArduinoBoardManager arduino = ArduinoBoardManager();
 
 void setup() {
@@ -25,7 +24,8 @@ void setup() {
   Serial.print(" is an "); Serial.print(ArduinoBoardManager::NUM_BITS);
   Serial.print("-bit, "); Serial.print(ArduinoBoardManager::MAX_MHZ/M);
   Serial.print("Mhz processor with "); Serial.print(ArduinoBoardManager::SRAM_SIZE/k);
-  Serial.print("k of SRAM and "); Serial.print(ArduinoBoardManager::FLASH_SIZE/k);
+  Serial.print("k of SRAM, "); Serial.print(ArduinoBoardManager::EEPROM_SIZE/k);
+  Serial.print("k of EEPROM and "); Serial.print(ArduinoBoardManager::FLASH_SIZE/k);
   Serial.println("k of flash.");
   Serial.println();
   
@@ -43,7 +43,6 @@ void setup() {
     Serial.println("Your board supports bluetooth 4");
   }
 }
-
 
 void loop() {
 }

--- a/examples/featuresniffer/featuresniffer.ino
+++ b/examples/featuresniffer/featuresniffer.ino
@@ -7,7 +7,9 @@ void setup() {
   unsigned int k = 1000;
   Serial.begin(9600);
 
-  while(!Serial); // on Leonardo/Micro, wait for serial
+  while(!Serial) {
+    // on Leonardo/Micro, wait for serial
+  }
   
   // The Arduino board name
   Serial.print("Board is compatible with Arduino ");
@@ -30,17 +32,27 @@ void setup() {
   Serial.println();
   
   // Board features (multiple serial ports on Mega, for example)
-  if (arduino.featureExists(ArduinoBoardManager::FEATURE_MULTIPLE_SERIAL)) {
+  if(arduino.featureExists(ArduinoBoardManager::FEATURE_MULTIPLE_SERIAL)) {
     Serial.println("Your board supports multiple serial connections");
-  } else {
+  } 
+  else {
     Serial.println("Your board only supports one serial connection");
   }
 
-  if (arduino.featureExists(ArduinoBoardManager::FEATURE_ANALOG_OUT)) {
+  if(arduino.featureExists(ArduinoBoardManager::FEATURE_ANALOG_OUT)) {
     Serial.println("Your board supports analog out");
   }
-  if (arduino.featureExists(ArduinoBoardManager::FEATURE_BLUETOOTH_4)) {
+
+  if(arduino.featureExists(ArduinoBoardManager::FEATURE_BLUETOOTH_4)) {
     Serial.println("Your board supports bluetooth 4");
+  }
+
+  if(arduino.featureExists(ArduinoBoardManager::FEATURE_ACCELEROMETER)) {
+    Serial.println("Your board supports accelerometer");
+  }
+
+  if(arduino.featureExists(ArduinoBoardManager::FEATURE_GYROSCOPE)) {
+    Serial.println("Your board supports gyroscope");
   }
 }
 


### PR DESCRIPTION
These fixes include:

- using bitwise operations to store board feature sets
- fix for incorrect NUM_FEATURES constant (i.e. NUM_FEATURES is removed)
- fix ATmega2560 compilation error
- removal of duplicate (and incorrect) constant definitions from ArduinoBoardManager constructor
- usage of board defines rather than hard coded literals
- add header guard to avoid multiple #includes
- separate out ATmega1280 and ATmega2560 to correct CPU_NAME